### PR TITLE
Ignore `torch.distributed.reduce_scatter`.

### DIFF
--- a/pyprof/nvtx/nvmarker.py
+++ b/pyprof/nvtx/nvmarker.py
@@ -91,7 +91,7 @@ def isfunc(mod, f):
         '__iter__', '__len__', '__loader__', '__module__', '__name__', '__new__', '__nonzero__', '__package__',
         '__path__', '__reduce__', '__reduce_ex__', '__repr__', '__reversed__', '__setattr__', '__setitem__',
         '__setstate__', '__sizeof__', '__spec__', '__str__', '__subclasshook__', '__version__',
-        '__weakref__', 'is_floating_point', 'is_tensor', 'type'
+        '__weakref__', 'is_floating_point', 'is_tensor', 'type', 'reduce_scatter'
     ]
 
     #Add functions to this list if they cause recursion


### PR DESCRIPTION
The apex lib checks if it supports `no_copy`, and fails otherwise.